### PR TITLE
HCC descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,29 @@ If a member has a different eligibility status, change the eligibility as follow
 }
 ```
 
+### HCC-Describing a Hierachical Condition Category
+
+To get the description, hierarchy parents and children of a HCC:
+
+```python
+>>> hcc_doc = he.describe_hcc("HCC19")  # either "HCC19", "hcc19" or "19"
+>>> print(json.dumps(hcc_doc, indent=2))
+{
+  "description": "Diabetes without Complication",
+  "children": [],
+  "parents": [
+    "HCC17",
+    "HCC18"
+  ]
+}
+```
+
 ## License
 Apache 2.0
 
 ## Authors
 - Yubin Park, PhD
+- Thomas Chen
 
 ## References
 - https://www.nber.org/data/cms-risk-adjustment.html

--- a/hccpy/hcc.py
+++ b/hccpy/hcc.py
@@ -119,7 +119,19 @@ class HCCEngine:
       cc : str
            The Condition Category of interest
       """
-      cc = cc.upper().replace("HCC", "")  # cc needs no prefix "HCC"
-      cc_desc = self.label.get(cc, "N/A")
-      return cc_desc
+      cc = cc.upper()
+      cc_desc = self.label.get(cc.replace("HCC", ""), "N/A")  # cc needs no prefix "HCC"
+      if "HCC" not in cc:
+          cc = "HCC{}".format(cc)
+      cc_children = self.hier.get(cc, [])
+      cc_parents = []
+      for k, v in self.hier.items():
+          if cc in v:
+              cc_parents.append(k)
+      out = {
+          "description": cc_desc,
+          "children": cc_children,
+          "parents": cc_parents
+      }
+      return out
 

--- a/hccpy/hcc.py
+++ b/hccpy/hcc.py
@@ -111,4 +111,15 @@ class HCCEngine:
                 }
         return out
 
+    def describe_hcc(self, cc):
+      """Return the medical description of a given Condition Category
+
+      Parameters
+      ----------
+      cc : str
+           The Condition Category of interest
+      """
+      cc = cc.upper().replace("HCC", "")  # cc needs no prefix "HCC"
+      cc_desc = self.label.get(cc, "N/A")
+      return cc_desc
 

--- a/tests/hcc_tests.py
+++ b/tests/hcc_tests.py
@@ -65,6 +65,23 @@ class TestHCCEngine(unittest.TestCase):
         self.assertTrue(np.isclose(rp["risk_score"], 1.3))
 
 
+    def test_hccdescription(self):
+
+        he = HCCEngine()
+
+        desc = he.describe_hcc("19")
+        self.assertTrue(desc == "Diabetes without Complication")
+
+        desc = he.describe_hcc("HCC19")
+        self.assertTrue(desc == "Diabetes without Complication")
+
+        desc = he.describe_hcc("hcc19")
+        self.assertTrue(desc == "Diabetes without Complication")
+
+        desc = he.describe_hcc("3")
+        self.assertTrue(desc == "N/A")
+
+
 if __name__ == "__main__":
 
     unittest.main()

--- a/tests/hcc_tests.py
+++ b/tests/hcc_tests.py
@@ -51,7 +51,6 @@ class TestHCCEngine(unittest.TestCase):
         self.assertTrue(np.isclose(rp["risk_score"], 1.322))
 
 
-
     def test_version(self):
 
         he = HCCEngine(version="22")
@@ -69,17 +68,37 @@ class TestHCCEngine(unittest.TestCase):
 
         he = HCCEngine()
 
-        desc = he.describe_hcc("19")
-        self.assertTrue(desc == "Diabetes without Complication")
+        doc = he.describe_hcc("19")
+        self.assertTrue(doc["description"] == "Diabetes without Complication")
 
-        desc = he.describe_hcc("HCC19")
-        self.assertTrue(desc == "Diabetes without Complication")
+        doc = he.describe_hcc("HCC19")
+        self.assertTrue(doc["description"] == "Diabetes without Complication")
 
-        desc = he.describe_hcc("hcc19")
-        self.assertTrue(desc == "Diabetes without Complication")
+        doc = he.describe_hcc("hcc19")
+        self.assertTrue(doc["description"] == "Diabetes without Complication")
 
-        desc = he.describe_hcc("3")
-        self.assertTrue(desc == "N/A")
+        doc = he.describe_hcc("3")
+        self.assertTrue(doc["description"] == "N/A")
+
+
+    def test_hccfamily(self):
+
+        he = HCCEngine()
+
+        doc = he.describe_hcc("19")
+        self.assertTrue("HCC17" in doc["parents"])
+        self.assertTrue("HCC18" in doc["parents"])
+
+        doc = he.describe_hcc("HCC19")
+        self.assertTrue("HCC17" in doc["parents"])
+        self.assertTrue("HCC18" in doc["parents"])
+
+        doc = he.describe_hcc("HCC19")
+        self.assertTrue(len(doc["children"]) == 0)
+
+        doc = he.describe_hcc("17")
+        self.assertTrue("HCC18" in doc["children"])
+        self.assertTrue("HCC19" in doc["children"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A new helper function `describe_hcc` was introduced into the engine. This function is designed to help users obtain all relevant information of a HCC, including its description, hierarchy parents and children. The implementation of the function uses only the class variable`label` and leaves the core logic and all other variables intact.

In terms of testing, two test functions - `test_hccdescription` and `test_hccfamily` were added and executed successfully.