### PR TITLE
Addressed issue 23

### DIFF
--- a/hccpy/_V2218O1P.py
+++ b/hccpy/_V2218O1P.py
@@ -1,15 +1,15 @@
 
-def get_risk_dct(coefn, hcc_lst, age, sex, elig, origds):
+def get_risk_dct(coefn, hcc_lst, age, sex, elig, origds, medicaid):
 
     risk_dct = {}
 
-    # demographic factors
-
+    # build demographic bracket strings and add to risk_dct
     elig_demo = elig 
     if elig[:3] in {"CFA", "CFD", "CNA", "CND", "CPA", "CPD", "INS"}:
         elig_demo += "_" 
     elig_demo += sex
 
+    # build age bracket strings and add to risk_dct
     age_ranges = [x for x in coefn.keys() if elig_demo in x]
     age_match = ""
     for age_range in age_ranges:
@@ -26,29 +26,26 @@ def get_risk_dct(coefn, hcc_lst, age, sex, elig, origds):
         if lb <= age < ub:
             age_match = age_range
             break
-    if age_match in coefn:
-        risk_dct[age_match] = coefn[age_match]
-    elif age_match != "":
-        risk_dct[age_match] = 0.0 # NOTE: default value
-
+    risk_dct[age_match] = coefn.get(age_match, 0.0)
+    
+    # build original entitlement string and add to risk_dct
     if origds > 0:
         elig_origds = elig + "_OriginallyDisabled_"
         if sex == "M":
             elig_origds += "Male" 
         else:
-            elig_origds += "Female" 
-        if elig_origds in coefn:
-            risk_dct[elig_origds] = coefn[elig_origds]
-        else:
-            risk_dct[elig_origds] = 0.0 # NOTE: default value
+            elig_origds += "Female"     
+        risk_dct[elig_origds] = coefn.get(elig_origds, 0.0)
+    
+    # build medicaid interacion and add to risk_dict
+    if medicaid:
+        mcd_hcc = elig + "_" + "LTIMCAID"
+        risk_dct[mcd_hcc] = coefn.get(mcd_hcc, 0.0)
 
-    # hcc factors
+    # build hcc factor strings and add to risk_dict
     for hcc in hcc_lst:
         elig_hcc = elig + "_" + hcc
-        if elig_hcc in coefn:
-            risk_dct[elig_hcc] = coefn[elig_hcc]
-        else:
-            risk_dct[elig_hcc] = 0.0 # NOTE: default value
+        risk_dct[elig_hcc] = coefn.get(elig_hcc, 0.0)
 
     return risk_dct
 

--- a/hccpy/_V2419P1M.py
+++ b/hccpy/_V2419P1M.py
@@ -5,6 +5,7 @@ def create_interactions(cc_lst, DISABL, age):
     x = Counter(cc_lst) 
     z = Counter()
 
+    # payable HCC's count interaction
     hcccnt = len([k for k in x.keys() if "HCC" in k])
     if hcccnt > 9:
         x["D10P"] = 1
@@ -26,24 +27,21 @@ def create_interactions(cc_lst, DISABL, age):
                                 x["HCC59"], x["HCC60"])
 
     # community model interactions
+    # NOTE: updated interaction codes to match V24hcccoefn.csv; values changed from V23 --> V24
     x["HCC47_gCancer"] = x["HCC47"] * z["CANCER"]
-    x["HCC85_gDiabetesMellit"] = x["HCC85"] * z["DIABETES"]
-    x["HCC85_gCopdCF"] = x["HCC85"] * z["gCopdCF"]
+    x["DIABETES_CHF"] = x["HCC85"] * z["DIABETES"]
+    x["CHF_gCopdCF"] = x["HCC85"] * z["gCopdCF"]
     x["HCC85_gRenal_V24"] = x["HCC85"] * z["RENAL_V24"]
-    x["gRespDepandArre_gCopdCF"] = z["CARD_RESP_FAIL"] * z["gCopdCF"]
+    x["gCopdCF_CARD_RESP_FAIL"] = z["CARD_RESP_FAIL"] * z["gCopdCF"]
     x["HCC85_HCC96"] = x["HCC85"] * x["HCC96"]
     x["gSubstanceAbuse_gPsychiatric_V24"] = (z["gPsychiatric_V24"] * 
                                         z["gSubstanceAbuse_V24"])
     
     # institutional model interactions
     x["PRESSURE_ULCER"] = max(x["HCC157"], x["HCC158"], x["HCC159"])
-    # NOTE: these are removed in V24; existed in V23
-    #x["CHF_gCopdCF"] = z["CHF"] * z["gCopdCF"] # 
-    #x["gCopdCF_CARD_RESP_FAIL"] = z["gCopdCF"] * z["CARD_RESP_FAIL"]
     x["SEPSIS_PRESSURE_ULCER"] = z["SEPSIS"] * x["PRESSURE_ULCER"]
     x["SEPSIS_ARTIF_OPENINGS"] = z["SEPSIS"] * x["HCC188"]
     x["ART_OPENINGS_PRESSURE_ULCER"] = x["HCC188"]*x["PRESSURE_ULCER"]
-    #x["DIABETES_CHF"] = z["DIABETES"] * z["CHF"]
     x["gCopdCF_ASP_SPEC_B_PNEUM"]  = z["gCopdCF"] * x["HCC114"]
     x["ASP_SPEC_BACT_PNEUM_PRES_ULC"] = x["HCC114"]*x["PRESSURE_ULCER"]
     x["SEPSIS_ASP_SPEC_BACT_PNEUM"] = x["SEPSIS"] * x["HCC114"]
@@ -57,9 +55,6 @@ def create_interactions(cc_lst, DISABL, age):
     x["DISABLED_HCC39"] = DISABL * x["HCC39"]
     x["DISABLED_HCC77"] = DISABL * x["HCC77"]
     x["DISABLED_HCC6"] = DISABL * x["HCC6"]   
-
-    #if age < 65 and x["gSubstanceAbuse_gPsychiatric_V23"] > 0:
-    #    x["disable_substAbuse_psych_V23"] = 1
 
     cc_lst = [k for k, v in x.items() if v > 0]
 

--- a/hccpy/hcc.py
+++ b/hccpy/hcc.py
@@ -124,7 +124,7 @@ class HCCEngine:
         hcc_lst = self._apply_hierarchy(cc_dct, age, sex)
         hcc_lst = self._apply_interactions(hcc_lst, age, disabled)
         risk_dct = V2218O1P.get_risk_dct(self.coefn, hcc_lst, age, 
-                                        sex, elig, origds)
+                                        sex, elig, origds, medicaid)
 
         score = np.sum([x for x in risk_dct.values()])
         out = {

--- a/tests/hcc_tests.py
+++ b/tests/hcc_tests.py
@@ -40,15 +40,15 @@ class TestHCCEngine(unittest.TestCase):
         he = HCCEngine()
 
         rp = he.profile(["E1169", "I509"], age=70, sex="M", elig="CNA")
-        self.assertTrue(np.isclose(rp["risk_score"], 1.027))
+        self.assertTrue(np.isclose(rp["risk_score"], 1.148))
 
         rp = he.profile(["E1169", "I5030", "I509", "I211", "I209", "R05"],
                         age=70, sex="M", elig="CNA")
-        self.assertTrue(np.isclose(rp["risk_score"], 1.162))
+        self.assertTrue(np.isclose(rp["risk_score"], 1.283))
 
         rp = he.profile(["E1169", "I5030", "I509", "I211", "I209", "R05"],
                         age=45, sex="F", elig="CND")
-        self.assertTrue(np.isclose(rp["risk_score"], 1.257))
+        self.assertTrue(np.isclose(rp["risk_score"], 1.281))
 
 
     def test_versionyear(self):
@@ -66,8 +66,18 @@ class TestHCCEngine(unittest.TestCase):
         he = HCCEngine(version="24")
         rp = he.profile(["E1169", "I5030", "I509", "I211", "I209", "R05"],
                         age=70, sex="M", elig="CNA")
-        self.assertTrue(np.isclose(rp["risk_score"], 1.162))
+        self.assertTrue(np.isclose(rp["risk_score"], 1.283))
         self.assertTrue("CNA_D3" in rp["details"])
+        
+        # Test interactions
+        rp = he.profile(["E109", "I509"],
+                        age=80, sex="M", elig="CPA", orec="0", medicaid=True)
+        self.assertTrue(np.isclose(rp["risk_score"], 1.08)) # CHF + Diabetes
+        
+        rp = he.profile(["A021"],
+                        age=64, sex="M", elig="INS", orec="0", medicaid=True)
+        self.assertTrue(np.isclose(rp["risk_score"], 1.446)) # INS + Medicaid
+        
 
     def test_hccdescription(self):
 


### PR DESCRIPTION
- Updated V24 interaction strings to match V24hcccoefn.csv values.
- Parameterized medicaid to get_risk_dict function.
- Updated to use .get() syntax to be concise in defaulting to zero score
- Some minor comment updates
- Corrected test suite to account for V24 interactions and added test for institutional / medicaid interaction