### PR TITLE
add parameter no_hierarchy to avoid hcc hierarchy

### DIFF
--- a/hccpy/hcc.py
+++ b/hccpy/hcc.py
@@ -95,7 +95,7 @@ class HCCEngine:
         return sex
 
     def profile(self, dx_lst, age=70, sex="M", 
-                    elig="CNA", orec="0", medicaid=False):
+                    elig="CNA", orec="0", medicaid=False, no_hierarchy = False):
         """Returns the HCC risk profile of a given patient information.
 
         Parameters
@@ -126,6 +126,8 @@ class HCCEngine:
               - "3": Both DIB and ESRD
         medicaid: bool
                   If the patient is in Medicaid or not.
+        no_hierarchy: bool
+                  If you want to avoid hcc hierarchy and get scores for all codes
         """
 
         sex = self._sexmap(sex)
@@ -134,7 +136,10 @@ class HCCEngine:
         dx_set = {dx.strip().upper().replace(".","") for dx in dx_lst}
         cc_dct = {dx:self.dx2cc[dx] for dx in dx_set if dx in self.dx2cc}
         cc_dct = V22I0ED2.apply_agesex_edits(cc_dct, age, sex)
-        hcc_lst = self._apply_hierarchy(cc_dct, age, sex)
+        if no_hierarchy:
+            hcc_lst = cc_dct.values()
+        else:
+            hcc_lst = self._apply_hierarchy(cc_dct, age, sex)
         hcc_lst = self._apply_interactions(hcc_lst, age, disabled)
         risk_dct = V2218O1P.get_risk_dct(self.coefn, hcc_lst, age, 
                                         sex, elig, origds, medicaid)


### PR DESCRIPTION
For users who do want to use the hierarchy but a simple mapping from ICD10 to HCC and RAF Scores, this parameter will facilitate that function.