### PR TITLE
bump age from 64 to 65 if orec equals 0

### DIFF
--- a/hccpy/hcc.py
+++ b/hccpy/hcc.py
@@ -154,6 +154,11 @@ class HCCEngine:
             sex = smap[sex.lower()]
         return sex
 
+    def _agemap(self, age, orec):
+        if(age == 64 and orec == "0"):
+            age = 65
+        return age
+
     def profile(self, dx_lst, age=70, sex="M", 
                     elig="CNA", orec="0", medicaid=False):
         """Returns the HCC risk profile of a given patient information.
@@ -189,6 +194,7 @@ class HCCEngine:
         """
 
         sex = self._sexmap(sex)
+        age = self._agemap(age, orec)
         disabled, origds, elig = AGESEXV2.get_ds(age, orec, medicaid, elig)
 
         dx_set = {dx.strip().upper().replace(".","") for dx in dx_lst}


### PR DESCRIPTION
The SAS implementation magically bumps patient age from 64 to 65 if the OREC is 0. I imagine the presumption is that if the OREC is in fact 0 then the age is probably being misreported slightly.

https://github.com/yubin-park/hccpy/blob/8b52caefbfad07495a761c56a1e32e6a214ca800/hccpy/data/V2419P1M.TXT#L348

This diff is a way to achieve the same effect in the python.